### PR TITLE
Add client-specifc token lifetimes.

### DIFF
--- a/lib/authCodeGrant.js
+++ b/lib/authCodeGrant.js
@@ -16,7 +16,8 @@
 
 var error = require('./error'),
   runner = require('./runner'),
-  token = require('./token');
+  token = require('./token'),
+  util = require('./util');
 
 module.exports = AuthCodeGrant;
 
@@ -171,8 +172,12 @@ function generateCode (done) {
  * @this   OAuth
  */
 function saveAuthCode (done) {
+  var lifetime = util.numeric(this.client.authCodeLifetime) ?
+    this.client.authCodeLifetime : this.config.authCodeLifetime;
+
   var expires = new Date();
-  expires.setSeconds(expires.getSeconds() + this.config.authCodeLifetime);
+  expires.setSeconds(expires.getSeconds() + lifetime);
+  console.log(expires, lifetime)
 
   this.model.saveAuthCode(this.authCode, this.client.clientId, expires,
       this.user, function (err) {

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -17,7 +17,8 @@
 var auth = require('basic-auth'),
   error = require('./error'),
   runner = require('./runner'),
-  token = require('./token');
+  token = require('./token'),
+  util = require('./util');
 
 module.exports = Grant;
 
@@ -390,9 +391,13 @@ function saveAccessToken (done) {
   }
 
   var expires = null;
-  if (this.config.accessTokenLifetime !== null) {
+  var client = this.req.oauth.client;
+  this.accessTokenLifetime = util.numeric(client.accessTokenLifetime) ?
+    client.accessTokenLifetime : this.config.accessTokenLifetime;
+
+  if (this.accessTokenLifetime !== null) {
     expires = new Date(this.now);
-    expires.setSeconds(expires.getSeconds() + this.config.accessTokenLifetime);
+    expires.setSeconds(expires.getSeconds() + this.accessTokenLifetime);
   }
 
   this.model.saveAccessToken(accessToken, this.client.clientId, expires,
@@ -436,9 +441,13 @@ function saveRefreshToken (done) {
   }
 
   var expires = null;
-  if (this.config.refreshTokenLifetime !== null) {
+  var lifetime = util.numeric(this.req.oauth.client.refreshTokenLifetime) ?
+    this.req.oauth.client.refreshTokenLifetime :
+    this.config.refreshTokenLifetime;
+
+  if (lifetime !== null) {
     expires = new Date(this.now);
-    expires.setSeconds(expires.getSeconds() + this.config.refreshTokenLifetime);
+    expires.setSeconds(expires.getSeconds() + lifetime);
   }
 
   this.model.saveRefreshToken(refreshToken, this.client.clientId, expires,
@@ -460,8 +469,8 @@ function sendResponse (done) {
     access_token: this.accessToken
   };
 
-  if (this.config.accessTokenLifetime !== null) {
-    response.expires_in = this.config.accessTokenLifetime;
+  if (this.accessTokenLifetime !== null) {
+    response.expires_in = this.accessTokenLifetime;
   }
 
   if (this.refreshToken) response.refresh_token = this.refreshToken;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2013-present NightWorld.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Check value is numeric
+ *
+ * @param {Mixed} value to check
+ */
+exports.numeric = function (value) {
+  return !isNaN(parseFloat(value)) && isFinite(value);
+}

--- a/test/authCodeGrant.js
+++ b/test/authCodeGrant.js
@@ -230,6 +230,34 @@ describe('AuthCodeGrant', function() {
       .end();
   });
 
+  it('should try to save auth code with a client-specific timeout', function (done) {
+    var app = bootstrap({
+      getClient: function (clientId, clientSecret, callback) {
+        callback(false, {
+          clientId: 'thom',
+          redirectUri: 'http://nightworld.com',
+          authCodeLifetime: 3600
+        });
+      },
+      saveAuthCode: function (authCode, clientId, expires, user, callback) {
+        should.exist(authCode);
+        authCode.should.have.lengthOf(40);
+        clientId.should.equal('thom');
+        (+expires).should.be.approximately((+new Date()) + (3600 * 1000), 100);
+        done();
+      }
+    }, [false, true]);
+
+    request(app)
+      .post('/authorise')
+      .send({
+        response_type: 'code',
+        client_id: 'thom',
+        redirect_uri: 'http://nightworld.com'
+      })
+      .end();
+  });
+
   it('should accept valid request and return code using POST', function (done) {
     var code;
 


### PR DESCRIPTION
Closes #137
Fixes #98

Modifications from the following:

commit f3d225951390235b124d963e3b1b6cbbf0521a4d
Author: Michael Salinger mjsalinger@kinvey.com
Date:   Thu Feb 19 10:07:26 2015 -0500

```
Fixed custom timeouts not being properly displayed in the token endpoint response body
```

commit 2c02a15ef20b3bcb6f2ca116e7645c0f5267ca41
Author: Michael Salinger mjsalinger@kinvey.com
Date:   Tue Jan 27 07:01:43 2015 -0500

```
Changes based on pull request feedback
```

commit 341770e929f8fdc96324c98e2faa22a36fecd012
Author: Michael Salinger mjsalinger@kinvey.com
Date:   Tue Jan 20 11:27:08 2015 -0500

```
Fixes #98 - Addes client-specific token lifetimes

Adds three attributes to the client entity that determine the grant, access token, or refresh
token lifetime.  If any of the attributes is not present in the client object, the default config
value is used.

* authCodeLifetime
* accessTokenLifetime
* refreshTokenLifetime
```
